### PR TITLE
Feature/testing update

### DIFF
--- a/scalar/include/trid_cpu.h
+++ b/scalar/include/trid_cpu.h
@@ -52,12 +52,13 @@
 EXTERN_C
 tridStatus_t tridSmtsvStridedBatch(const float *a, const float *b,
                                    const float *c, float *d, float *u, int ndim,
-                                   int solvedim, int *dims, int *pads);
+                                   int solvedim, const int *dims,
+                                   const int *pads);
 EXTERN_C
 tridStatus_t tridDmtsvStridedBatch(const double *a, const double *b,
                                    const double *c, double *d, double *u,
-                                   int ndim, int solvedim, int *dims,
-                                   int *pads);
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *pads);
 
 //
 // Solve a batch of linear equation systems along a specified axis.
@@ -73,13 +74,13 @@ tridStatus_t tridDmtsvStridedBatch(const double *a, const double *b,
 EXTERN_C
 tridStatus_t tridSmtsvStridedBatchInc(const float *a, const float *b,
                                       const float *c, float *d, float *u,
-                                      int ndim, int solvedim, int *dims,
-                                      int *pads);
+                                      int ndim, int solvedim, const int *dims,
+                                      const int *pads);
 EXTERN_C
 tridStatus_t tridDmtsvStridedBatchInc(const double *a, const double *b,
                                       const double *c, double *d, double *u,
-                                      int ndim, int solvedim, int *dims,
-                                      int *pads);
+                                      int ndim, int solvedim, const int *dims,
+                                      const int *pads);
 
 EXTERN_C
 void trid_scalarS(const float *a, const float *b, const float *c, float *d,

--- a/scalar/include/trid_cuda.h
+++ b/scalar/include/trid_cuda.h
@@ -39,10 +39,10 @@
 //#include <cuda_complex.hpp>
 //typedef complex<float> complexf;
 //typedef complex<double> complexd;
-
-EXTERN_C
-void initTridMultiDimBatchSolve(int ndim, int *dims, int *pads);
-
+//
+// EXTERN_C
+// void initTridMultiDimBatchSolve(int ndim, int *dims, int *pads);
+//
 //tridStatus_t tridSgtsvStridedBatch(int sys_size, const float* a, const float *b, const float *c, float *d, int num_sys, int sys_stride);
 //tridStatus_t tridDgtsvStridedBatch(int sys_size, const double* a, const double *b, const double *c, double *d, int num_sys, int sys_stride);
 //tridStatus_t tridCgtsvStridedBatch(int sys_size, const complexf* a, const complexf *b, const complexf *c, complexf *d, int num_sys, int sys_stride);
@@ -54,34 +54,34 @@ void initTridMultiDimBatchSolve(int ndim, int *dims, int *pads);
 //tridStatus_t tridZgtsvStridedBatchInc(int sys_size, const complexd* a, const complexd *b, const complexd *c, complexd *d, complexd *u, int num_sys, int sys_stride);
 
 EXTERN_C
-tridStatus_t tridSmtsvStridedBatch(const float *a, const float *b, const float *c, float *d, float* u, int ndim, int solvedim, int *dims, int *pads, int *opts, int sync);
+tridStatus_t tridSmtsvStridedBatch(const float *a, const float *b, const float *c, float *d, float* u, int ndim, int solvedim, const int *dims, const int *pads, const int *opts, int sync);
 EXTERN_C
-tridStatus_t tridDmtsvStridedBatch(const double *a, const double *b, const double *c, double *d, double* u, int ndim, int solvedim, int *dims, int *pads, int *opts, int sync);
+tridStatus_t tridDmtsvStridedBatch(const double *a, const double *b, const double *c, double *d, double* u, int ndim, int solvedim, const int *dims, const int *pads, const int *opts, int sync);
 EXTERN_C
 tridStatus_t tridDmtsvStridedBatchPadded(const double *a, const int *a_pads,
                                    const double *b, const int *b_pads,
                                    const double *c, const int *c_pads,
                                    double *d, const int *d_pads,
                                    double *u, const int *u_pads,
-                                   int ndim, int solvedim, int *dims,
-                                   int *opts, int sync);
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *opts, int sync);
 //tridStatus_t tridSmtsvStridedBatch(int ndim, int* sys_size, const float* a, const float *b, const float *c, float *d, int *sys_stride, int solvedim);
 //tridStatus_t tridDmtsvStridedBatch(int ndim, int* sys_size, const double* a, const double *b, const double *c, double *d, int *sys_stride, int solvedim);
 //tridStatus_t tridCmtsvStridedBatch(int ndim, int* sys_size, const complexf* a, const complexf *b, const complexf *c, complexf *d, int *sys_stride, int solvedim);
 //tridStatus_t tridZmtsvStridedBatch(int ndim, int* sys_size, const complexd* a, const complexd *b, const complexd *c, complexd *d, int *sys_stride, int solvedim);
 
 EXTERN_C
-tridStatus_t tridSmtsvStridedBatchInc(const float *a, const float *b, const float *c, float *d, float* u, int ndim, int solvedim, int *dims, int *pads, int *opts, int sync);
+tridStatus_t tridSmtsvStridedBatchInc(const float *a, const float *b, const float *c, float *d, float* u, int ndim, int solvedim, const int *dims, const int *pads, const int *opts, int sync);
 EXTERN_C
-tridStatus_t tridDmtsvStridedBatchInc(const double *a, const double *b, const double *c, double *d, double* u, int ndim, int solvedim, int *dims, int *pads, int *opts, int sync);
+tridStatus_t tridDmtsvStridedBatchInc(const double *a, const double *b, const double *c, double *d, double* u, int ndim, int solvedim, const int *dims, const int *pads, const int *opts, int sync);
 EXTERN_C
 tridStatus_t tridDmtsvStridedBatchPaddedInc(const double *a, const int *a_pads,
                                    const double *b, const int *b_pads,
                                    const double *c, const int *c_pads,
                                    double *d, const int *d_pads,
                                    double *u, const int *u_pads,
-                                   int ndim, int solvedim, int *dims,
-                                   int *opts, int sync);
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *opts, int sync);
 //tridStatus_t tridSmtsvStridedBatchInc(int ndim, int* sys_size, const float* a, const float *b, const float *c, float *d, float *u, int *sys_stride, int solvedim);
 //tridStatus_t tridDmtsvStridedBatchInc(int ndim, int* sys_size, const double* a, const double *b, const double *c, double *d, double *u, int *sys_stride, int solvedim);
 //tridStatus_t tridCmtsvStridedBatchInc(int ndim, int* sys_size, const complexf* a, const complexf *b, const complexf *c, complexf *d, complexf *u, int *sys_stride, int solvedim);

--- a/scalar/src/cpu/transpose.hpp
+++ b/scalar/src/cpu/transpose.hpp
@@ -40,11 +40,11 @@
 
 #ifdef __AVX__
 // void transpose8x8_intrinsic(__m256 *ymm ) {
-#if defined(__clang__)
+#  if defined(__clang__)
 inline void transpose8x8_intrinsic(__m256 ymm[8]) {
-#else
+#  else
 inline void transpose8x8_intrinsic(__m256 __restrict__ ymm[8]) {
-#endif
+#  endif
   __m256 tmp[8];
 
   tmp[0] = _mm256_unpacklo_ps(ymm[0], ymm[1]);
@@ -85,11 +85,11 @@ inline void transpose8x8_intrinsic(__m256 __restrict__ ymm[8]) {
 }
 
 // void transpose4x4_intrinsic(__m256d *ymm ) {
-#if defined(__clang__)
+#  if defined(__clang__)
 inline void transpose4x4_intrinsic(__m256d ymm[4]) {
-#else
+#  else
 inline void transpose4x4_intrinsic(__m256d __restrict__ ymm[4]) {
-#endif
+#  endif
   __m256d tmp[4];
   tmp[0] = _mm256_permute2f128_pd(ymm[0], ymm[2], 0b00100000);
   tmp[1] = _mm256_permute2f128_pd(ymm[1], ymm[3], 0b00100000);
@@ -113,7 +113,7 @@ transpose16x16_intrinsic(__m512 __restrict__ zmm[16]) {
 // Transpose 2x2 blocks (block size is 8x8) within 16x16 matrix
 #    pragma unroll(16 / 2)
   for (int i = 0; i < 16 / 2; ++i) {
-    tmp[i] = _mm512_mask_permute4f128_ps(zmm[i], 0b1111111100000000,
+    tmp[i]            = _mm512_mask_permute4f128_ps(zmm[i], 0b1111111100000000,
                                          zmm[(16 / 2) + i], _MM_PERM_BACD);
     tmp[(16 / 2) + i] = _mm512_mask_permute4f128_ps(
         zmm[(16 / 2) + i], 0b0000000011111111, zmm[i], _MM_PERM_BADC);

--- a/scalar/src/cpu/trid_cpu.cpp
+++ b/scalar/src/cpu/trid_cpu.cpp
@@ -398,12 +398,14 @@ void trid_scalar(const FP *__restrict a, const FP *__restrict b,
 // Function for selecting the proper setup for solve in a specific dimension
 //
 void tridMultiDimBatchSolve(const FP *a, const FP *b, const FP *c, FP *d, FP *u,
-                            int ndim, int solvedim, int *dims_p, int *pads,
-                            int inc) {
+                            int ndim, int solvedim, const int *dims_p,
+                            const int *pads_p, int inc) {
 
   int dims[3] = {1, 1, 1};
+  int pads[3] = {1, 1, 1};
   for(int i = 0; i < ndim; i++) {
     dims[i] = dims_p[i];
+    pads[i] = pads_p[i];
   }
   if (solvedim == 0) {
     int sys_stride = 1; // Stride between the consecutive elements of a system
@@ -532,15 +534,16 @@ void tridMultiDimBatchSolve(const FP *a, const FP *b, const FP *c, FP *d, FP *u,
 
 tridStatus_t tridSmtsvStridedBatch(const float *a, const float *b,
                                    const float *c, float *d, float *u, int ndim,
-                                   int solvedim, int *dims, int *pads) {
+                                   int solvedim, const int *dims,
+                                   const int *pads) {
   tridMultiDimBatchSolve(a, b, c, d, NULL, ndim, solvedim, dims, pads, 0);
   return TRID_STATUS_SUCCESS;
 }
 
 tridStatus_t tridSmtsvStridedBatchInc(const float *a, const float *b,
                                       const float *c, float *d, float *u,
-                                      int ndim, int solvedim, int *dims,
-                                      int *pads) {
+                                      int ndim, int solvedim, const int *dims,
+                                      const int *pads) {
   tridMultiDimBatchSolve(a, b, c, d, u, ndim, solvedim, dims, pads, 1);
   return TRID_STATUS_SUCCESS;
 }
@@ -578,16 +581,16 @@ void trid_scalar_vecSInc(const float *__restrict a, const float *__restrict b,
 
 tridStatus_t tridDmtsvStridedBatch(const double *a, const double *b,
                                    const double *c, double *d, double *u,
-                                   int ndim, int solvedim, int *dims,
-                                   int *pads) {
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *pads) {
   tridMultiDimBatchSolve(a, b, c, d, NULL, ndim, solvedim, dims, pads, 0);
   return TRID_STATUS_SUCCESS;
 }
 
 tridStatus_t tridDmtsvStridedBatchInc(const double *a, const double *b,
                                       const double *c, double *d, double *u,
-                                      int ndim, int solvedim, int *dims,
-                                      int *pads) {
+                                      int ndim, int solvedim, const int *dims,
+                                      const int *pads) {
   tridMultiDimBatchSolve(a, b, c, d, u, ndim, solvedim, dims, pads, 1);
   return TRID_STATUS_SUCCESS;
 }

--- a/scalar/src/cpu/trid_cpu.cpp
+++ b/scalar/src/cpu/trid_cpu.cpp
@@ -315,19 +315,19 @@ void trid_scalar_vec(const REAL *__restrict h_a, const REAL *__restrict h_b,
   //
   // forward pass
   //
-  bb    = ones / SIMD_LOAD_P(&h_b[0 * SIMD_VEC]);
-  cc    = bb * SIMD_LOAD_P(&h_c[0 * SIMD_VEC]);
-  dd    = bb * SIMD_LOAD_P(&h_d[0 * SIMD_VEC]);
+  bb    = ones / SIMD_LOAD_P(&h_b[0]);
+  cc    = bb * SIMD_LOAD_P(&h_c[0]);
+  dd    = bb * SIMD_LOAD_P(&h_d[0]);
   c2[0] = cc;
   d2[0] = dd;
 
   for (i = 1; i < N; i++) {
     ind   = ind + stride;
-    aa    = SIMD_LOAD_P(&h_a[ind * SIMD_VEC]);
-    bb    = SIMD_LOAD_P(&h_b[ind * SIMD_VEC]) - aa * cc;
-    dd    = SIMD_LOAD_P(&h_d[ind * SIMD_VEC]) - aa * dd;
+    aa    = SIMD_LOAD_P(&h_a[ind]);
+    bb    = SIMD_LOAD_P(&h_b[ind]) - aa * cc;
+    dd    = SIMD_LOAD_P(&h_d[ind]) - aa * dd;
     bb    = ones / bb;
-    cc    = bb * SIMD_LOAD_P(&h_c[ind * SIMD_VEC]);
+    cc    = bb * SIMD_LOAD_P(&h_c[ind]);
     dd    = bb * dd;
     c2[i] = cc;
     d2[i] = dd;
@@ -336,17 +336,16 @@ void trid_scalar_vec(const REAL *__restrict h_a, const REAL *__restrict h_b,
   // reverse pass
   //
   if (INC)
-    SIMD_STORE_P(&h_u[ind * SIMD_VEC], SIMD_LOAD_P(&h_u[ind * SIMD_VEC]) + dd);
+    SIMD_STORE_P(&h_u[ind], SIMD_LOAD_P(&h_u[ind]) + dd);
   else
-    SIMD_STORE_P(&h_d[ind * SIMD_VEC], dd);
+    SIMD_STORE_P(&h_d[ind], dd);
   for (i = N - 2; i >= 0; i--) {
     ind = ind - stride;
     dd  = d2[i] - c2[i] * dd;
     if (INC)
-      SIMD_STORE_P(&h_u[ind * SIMD_VEC],
-                   SIMD_LOAD_P(&h_u[ind * SIMD_VEC]) + dd);
+      SIMD_STORE_P(&h_u[ind], SIMD_LOAD_P(&h_u[ind]) + dd);
     else
-      SIMD_STORE_P(&h_d[ind * SIMD_VEC], dd);
+      SIMD_STORE_P(&h_d[ind], dd);
   }
 }
 
@@ -460,8 +459,7 @@ void tridMultiDimBatchSolve(const REAL *a, const REAL *b, const REAL *c,
       for (int i = 0; i < ROUND_DOWN(dims[0], SIMD_VEC); i += SIMD_VEC) {
         int ind = k * pads[0] * pads[1] + i;
         trid_scalar_vec<REAL, VECTOR, INC>(&a[ind], &b[ind], &c[ind], &d[ind],
-                                           &u[ind], sys_size,
-                                           sys_stride / SIMD_VEC);
+                                           &u[ind], sys_size, sys_stride);
       }
     }
     if (ROUND_DOWN(dims[0], SIMD_VEC) <
@@ -487,8 +485,7 @@ void tridMultiDimBatchSolve(const REAL *a, const REAL *b, const REAL *c,
       for (int i = 0; i < ROUND_DOWN(dims[0], SIMD_VEC); i += SIMD_VEC) {
         int ind = j * pads[0] + i;
         trid_scalar_vec<REAL, VECTOR, INC>(&a[ind], &b[ind], &c[ind], &d[ind],
-                                           &u[ind], sys_size,
-                                           (sys_stride) / SIMD_VEC);
+                                           &u[ind], sys_size, sys_stride);
       }
     }
     if (ROUND_DOWN(dims[0], SIMD_VEC) <

--- a/scalar/src/cpu/trid_cpu.cpp
+++ b/scalar/src/cpu/trid_cpu.cpp
@@ -158,7 +158,7 @@ void trid_x_transpose(const FP *__restrict a, const FP *__restrict b,
   //
   // forward pass
   //
-  int n = 0;
+  int n         = 0;
   SIMD_REG ones = SIMD_SET1_P(1.0F);
 
   LOAD(a_reg, a, n, sys_pad);
@@ -172,10 +172,10 @@ void trid_x_transpose(const FP *__restrict a, const FP *__restrict b,
 #elif FPPREC == 1
   bb = SIMD_DIV_P(ones, bb);
 #endif
-  cc = c_reg[0];
-  cc = SIMD_MUL_P(bb, cc);
-  dd = d_reg[0];
-  dd = SIMD_MUL_P(bb, dd);
+  cc    = c_reg[0];
+  cc    = SIMD_MUL_P(bb, cc);
+  dd    = d_reg[0];
+  dd    = SIMD_MUL_P(bb, dd);
   c2[0] = cc;
   d2[0] = dd;
 
@@ -193,8 +193,8 @@ void trid_x_transpose(const FP *__restrict a, const FP *__restrict b,
 #elif FPPREC == 1
     bb = SIMD_DIV_P(ones, bb);
 #endif
-    cc = SIMD_MUL_P(bb, c_reg[i]);
-    dd = SIMD_MUL_P(bb, dd);
+    cc        = SIMD_MUL_P(bb, c_reg[i]);
+    dd        = SIMD_MUL_P(bb, dd);
     c2[n + i] = cc;
     d2[n + i] = dd;
   }
@@ -218,8 +218,8 @@ void trid_x_transpose(const FP *__restrict a, const FP *__restrict b,
 #elif FPPREC == 1
       bb = SIMD_DIV_P(ones, bb);
 #endif
-      cc = SIMD_MUL_P(bb, c_reg[i]);
-      dd = SIMD_MUL_P(bb, dd);
+      cc        = SIMD_MUL_P(bb, c_reg[i]);
+      dd        = SIMD_MUL_P(bb, dd);
       c2[n + i] = cc;
       d2[n + i] = dd;
     }
@@ -245,14 +245,14 @@ void trid_x_transpose(const FP *__restrict a, const FP *__restrict b,
 #elif FPPREC == 1
       bb = SIMD_DIV_P(ones, bb);
 #endif
-      cc = SIMD_MUL_P(bb, c_reg[i]);
-      dd = SIMD_MUL_P(bb, dd);
+      cc        = SIMD_MUL_P(bb, c_reg[i]);
+      dd        = SIMD_MUL_P(bb, dd);
       c2[n + i] = cc;
       d2[n + i] = dd;
     }
     d_reg[i - 1] = dd;
     for (i = i - 2; i >= 0; i--) {
-      dd = SIMD_SUB_P(d2[n + i], SIMD_MUL_P(c2[n + i], dd));
+      dd       = SIMD_SUB_P(d2[n + i], SIMD_MUL_P(c2[n + i], dd));
       d_reg[i] = dd;
     }
     if (inc) {
@@ -270,7 +270,7 @@ void trid_x_transpose(const FP *__restrict a, const FP *__restrict b,
     d_reg[SIMD_VEC - 1] = dd;
     n -= SIMD_VEC;
     for (i = SIMD_VEC - 2; i >= 0; i--) {
-      dd = SIMD_SUB_P(d2[n + i], SIMD_MUL_P(c2[n + i], dd));
+      dd       = SIMD_SUB_P(d2[n + i], SIMD_MUL_P(c2[n + i], dd));
       d_reg[i] = dd;
     }
     if (inc) {
@@ -284,7 +284,7 @@ void trid_x_transpose(const FP *__restrict a, const FP *__restrict b,
 
   for (n = (sys_size / SIMD_VEC) * SIMD_VEC - SIMD_VEC; n >= 0; n -= SIMD_VEC) {
     for (i = (SIMD_VEC - 1); i >= 0; i--) {
-      dd = SIMD_SUB_P(d2[n + i], SIMD_MUL_P(c2[n + i], dd));
+      dd       = SIMD_SUB_P(d2[n + i], SIMD_MUL_P(c2[n + i], dd));
       d_reg[i] = dd;
     }
     if (inc) {
@@ -314,20 +314,20 @@ void trid_scalar_vec(const REAL *__restrict h_a, const REAL *__restrict h_b,
   //
   // forward pass
   //
-  bb = ones / SIMD_LOAD_P(&h_b[0*SIMD_VEC]);
-  cc = bb * SIMD_LOAD_P(&h_c[0*SIMD_VEC]);
-  dd = bb * SIMD_LOAD_P(&h_d[0*SIMD_VEC]);
+  bb    = ones / SIMD_LOAD_P(&h_b[0 * SIMD_VEC]);
+  cc    = bb * SIMD_LOAD_P(&h_c[0 * SIMD_VEC]);
+  dd    = bb * SIMD_LOAD_P(&h_d[0 * SIMD_VEC]);
   c2[0] = cc;
   d2[0] = dd;
 
   for (i = 1; i < N; i++) {
-    ind = ind + stride;
-    aa = SIMD_LOAD_P(&h_a[ind*SIMD_VEC]);
-    bb = SIMD_LOAD_P(&h_b[ind*SIMD_VEC]) - aa * cc;
-    dd = SIMD_LOAD_P(&h_d[ind*SIMD_VEC]) - aa * dd;
-    bb = ones / bb;
-    cc = bb * SIMD_LOAD_P(&h_c[ind*SIMD_VEC]);
-    dd = bb * dd;
+    ind   = ind + stride;
+    aa    = SIMD_LOAD_P(&h_a[ind * SIMD_VEC]);
+    bb    = SIMD_LOAD_P(&h_b[ind * SIMD_VEC]) - aa * cc;
+    dd    = SIMD_LOAD_P(&h_d[ind * SIMD_VEC]) - aa * dd;
+    bb    = ones / bb;
+    cc    = bb * SIMD_LOAD_P(&h_c[ind * SIMD_VEC]);
+    dd    = bb * dd;
     c2[i] = cc;
     d2[i] = dd;
   }
@@ -335,16 +335,17 @@ void trid_scalar_vec(const REAL *__restrict h_a, const REAL *__restrict h_b,
   // reverse pass
   //
   if (INC)
-    SIMD_STORE_P(&h_u[ind*SIMD_VEC], SIMD_LOAD_P(&h_u[ind*SIMD_VEC]) + dd);
+    SIMD_STORE_P(&h_u[ind * SIMD_VEC], SIMD_LOAD_P(&h_u[ind * SIMD_VEC]) + dd);
   else
-    SIMD_STORE_P(&h_d[ind*SIMD_VEC], dd);
+    SIMD_STORE_P(&h_d[ind * SIMD_VEC], dd);
   for (i = N - 2; i >= 0; i--) {
     ind = ind - stride;
-    dd = d2[i] - c2[i] * dd;
+    dd  = d2[i] - c2[i] * dd;
     if (INC)
-      SIMD_STORE_P(&h_u[ind*SIMD_VEC], SIMD_LOAD_P(&h_u[ind*SIMD_VEC]) + dd);
+      SIMD_STORE_P(&h_u[ind * SIMD_VEC],
+                   SIMD_LOAD_P(&h_u[ind * SIMD_VEC]) + dd);
     else
-      SIMD_STORE_P(&h_d[ind*SIMD_VEC], dd);
+      SIMD_STORE_P(&h_d[ind * SIMD_VEC], dd);
   }
 }
 
@@ -360,20 +361,20 @@ void trid_scalar(const FP *__restrict a, const FP *__restrict b,
   //
   // forward pass
   //
-  bb = 1.0F / b[0];
-  cc = bb * c[0];
-  dd = bb * d[0];
+  bb    = 1.0F / b[0];
+  cc    = bb * c[0];
+  dd    = bb * d[0];
   c2[0] = cc;
   d2[0] = dd;
 
   for (i = 1; i < N; i++) {
-    ind = ind + stride;
-    aa = a[ind];
-    bb = b[ind] - aa * cc;
-    dd = d[ind] - aa * dd;
-    bb = 1.0F / bb;
-    cc = bb * c[ind];
-    dd = bb * dd;
+    ind   = ind + stride;
+    aa    = a[ind];
+    bb    = b[ind] - aa * cc;
+    dd    = d[ind] - aa * dd;
+    bb    = 1.0F / bb;
+    cc    = bb * c[ind];
+    dd    = bb * dd;
     c2[i] = cc;
     d2[i] = dd;
   }
@@ -386,7 +387,7 @@ void trid_scalar(const FP *__restrict a, const FP *__restrict b,
     d[ind] = dd;
   for (i = N - 2; i >= 0; i--) {
     ind = ind - stride;
-    dd = d2[i] - c2[i] * dd;
+    dd  = d2[i] - c2[i] * dd;
     if (INC)
       u[ind] += dd;
     else
@@ -403,19 +404,21 @@ void tridMultiDimBatchSolve(const FP *a, const FP *b, const FP *c, FP *d, FP *u,
 
   int dims[3] = {1, 1, 1};
   int pads[3] = {1, 1, 1};
-  for(int i = 0; i < ndim; i++) {
+  for (int i = 0; i < ndim; i++) {
     dims[i] = dims_p[i];
     pads[i] = pads_p[i];
   }
   if (solvedim == 0) {
     int sys_stride = 1; // Stride between the consecutive elements of a system
-    int sys_size = dims[0]; // Size (length) of a system
+    int sys_size   = dims[0]; // Size (length) of a system
     int sys_pads = pads[0]; // Padded sizes along each ndim number of dimensions
     int sys_n_lin =
         dims[1] * dims[2]; // = cumdims[solve] // Number of systems to be solved
 
     // FIXME fix and re-enable vectorisation in x-dim
-    if ((sys_pads % SIMD_VEC) == 0  && ((long)a & 0x3F)==0 && ((long)b & 0x3F)==0 && ((long)c & 0x3F)==0 && ((long)d & 0x3F)==0 && ((long)u & 0x3F)==0) {
+    if ((sys_pads % SIMD_VEC) == 0 && ((long)a & 0x3F) == 0 &&
+        ((long)b & 0x3F) == 0 && ((long)c & 0x3F) == 0 &&
+        ((long)d & 0x3F) == 0 && ((long)u & 0x3F) == 0) {
 #pragma omp parallel for collapse(2)
       for (int k = 0; k < dims[2]; k++) {
         for (int j = 0; j < ROUND_DOWN(dims[1], SIMD_VEC); j += SIMD_VEC) {

--- a/scalar/src/cpu/trid_mpi_cpu.cpp
+++ b/scalar/src/cpu/trid_mpi_cpu.cpp
@@ -833,7 +833,7 @@ inline void solve_reduced_pcr(const MpiSolverParams &params, REAL *aa, REAL *cc,
     }
 
     // Wait for receives to finish
-    MPI_Waitall(2, reqs, MPI_STATUS_IGNORE);
+    MPI_Waitall(4, reqs, MPI_STATUS_IGNORE);
     END_PROFILING("mpi_communication");
 
     // PCR algorithm
@@ -873,11 +873,6 @@ inline void solve_reduced_pcr(const MpiSolverParams &params, REAL *aa, REAL *cc,
       aa_r[id] = -am1 * aa_r[id] * bbi;
       cc_r[id] = -cp1 * cc_r[id] * bbi;
     }
-
-    BEGIN_PROFILING("mpi_communication");
-    // wait for sends to finish
-    MPI_Waitall(2, reqs + 2, MPI_STATUS_IGNORE);
-    END_PROFILING("mpi_communication");
 
     // done
     s = s << 1;

--- a/scalar/src/cpu/trid_mpi_cpu.cpp
+++ b/scalar/src/cpu/trid_mpi_cpu.cpp
@@ -679,7 +679,7 @@ inline void solve_reduced_jacobi(const MpiSolverParams &params, REAL *aa,
 #pragma omp parallel for
   for (int id = 0; id < n_sys; ++id) {
     int start = get_sys_start_idx(id, solvedim, dims, pads, ndim);
-    if (rank)
+    if (rank || nproc == 1)
       dd_r[id] = dd[start];
     else {
       dd_r[id] = 0;

--- a/scalar/src/cuda/trid_cuda.cu
+++ b/scalar/src/cuda/trid_cuda.cu
@@ -166,13 +166,12 @@ void transpose<double>(cublasHandle_t &handle, size_t mRows, size_t nCols, const
 }
 
 template <typename REAL, int INC>
-void tridMultiDimBatchSolve(const REAL *d_a, const int *a_pads,
-                            const REAL *d_b, const int *b_pads,
-                            const REAL *d_c, const int *c_pads,
-                            REAL *d_d, const int *d_pads,
-                            REAL *d_u, const int *u_pads,
-                            int ndim, int solvedim,
-                            int *dims, int *opts, int sync) {
+void tridMultiDimBatchSolve(const REAL *d_a, const int *a_pads, const REAL *d_b,
+                            const int *b_pads, const REAL *d_c,
+                            const int *c_pads, REAL *d_d, const int *d_pads,
+                            REAL *d_u, const int *u_pads, int ndim,
+                            int solvedim, const int *dims, const int *opts,
+                            int sync) {
 
   //int sys_n = cumdims[ndim] / dims[solvedim]; // Number of systems to be solved
   int sys_n = 1;
@@ -427,7 +426,6 @@ void tridMultiDimBatchSolve(const REAL *d_a, const int *a_pads,
   }
   if (sync == 1)
     cudaSafeCall(cudaDeviceSynchronize());
-
 }
 
 //------------------------------------------------------------------------------------------------------------------
@@ -500,20 +498,20 @@ void tridMultiDimBatchSolve(const REAL *d_a, const int *a_pads,
 
 tridStatus_t tridSmtsvStridedBatch(const float *a, const float *b,
                                    const float *c, float *d, float *u, int ndim,
-                                   int solvedim, int *dims, int *pads,
-                                   int *opts, int sync) {
-  tridMultiDimBatchSolve<float, 0>(a, pads, b, pads, c, pads, d, pads, NULL, pads,
-                                     ndim, solvedim, dims, opts, 1);
+                                   int solvedim, const int *dims,
+                                   const int *pads, const int *opts, int sync) {
+  tridMultiDimBatchSolve<float, 0>(a, pads, b, pads, c, pads, d, pads, NULL,
+                                   pads, ndim, solvedim, dims, opts, 1);
   return TRID_STATUS_SUCCESS;
 }
 
 
 tridStatus_t tridDmtsvStridedBatch(const double *a, const double *b,
                                    const double *c, double *d, double *u,
-                                   int ndim, int solvedim, int *dims, int *pads,
-                                   int *opts, int sync) {
-  tridMultiDimBatchSolve<double, 0>(a, pads, b, pads, c, pads, d, pads, NULL, pads,
-                                    ndim, solvedim, dims, opts, 1);
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *pads, const int *opts, int sync) {
+  tridMultiDimBatchSolve<double, 0>(a, pads, b, pads, c, pads, d, pads, NULL,
+                                    pads, ndim, solvedim, dims, opts, 1);
   return TRID_STATUS_SUCCESS;
 }
 
@@ -522,8 +520,8 @@ tridStatus_t tridDmtsvStridedBatchPadded(const double *a, const int *a_pads,
                                    const double *c, const int *c_pads,
                                    double *d, const int *d_pads,
                                    double *u, const int *u_pads,
-                                   int ndim, int solvedim, int *dims,
-                                   int *opts, int sync) {
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *opts, int sync) {
   tridMultiDimBatchSolve<double, 0>(a, a_pads, b, b_pads, c, c_pads, d, d_pads, NULL, u_pads,
                                     ndim, solvedim, dims, opts, 1);
   return TRID_STATUS_SUCCESS;
@@ -548,32 +546,32 @@ tridStatus_t tridDmtsvStridedBatchPadded(const double *a, const int *a_pads,
 
 tridStatus_t tridSmtsvStridedBatchInc(const float *a, const float *b,
                                       const float *c, float *d, float *u,
-                                      int ndim, int solvedim, int *dims,
-                                      int *pads, int *opts, int sync) {
+                                      int ndim, int solvedim, const int *dims,
+                                      const int *pads, const int *opts,
+                                      int sync) {
   tridMultiDimBatchSolve<float, 1>(a, pads, b, pads, c, pads, d, pads, u, pads,
-                                     ndim, solvedim, dims, opts, 1);
+                                   ndim, solvedim, dims, opts, 1);
   return TRID_STATUS_SUCCESS;
 }
 
 
 tridStatus_t tridDmtsvStridedBatchInc(const double *a, const double *b,
                                       const double *c, double *d, double *u,
-                                      int ndim, int solvedim, int *dims,
-                                      int *pads, int *opts, int sync) {
+                                      int ndim, int solvedim, const int *dims,
+                                      const int *pads, const int *opts,
+                                      int sync) {
   tridMultiDimBatchSolve<double, 1>(a, pads, b, pads, c, pads, d, pads, u, pads,
                                     ndim, solvedim, dims, opts, 1);
   return TRID_STATUS_SUCCESS;
 }
 
-tridStatus_t tridDmtsvStridedBatchPaddedInc(const double *a, const int *a_pads,
-                                   const double *b, const int *b_pads,
-                                   const double *c, const int *c_pads,
-                                   double *d, const int *d_pads,
-                                   double *u, const int *u_pads,
-                                   int ndim, int solvedim, int *dims,
-                                   int *opts, int sync) {
-  tridMultiDimBatchSolve<double, 1>(a, a_pads, b, b_pads, c, c_pads, d, d_pads, u, u_pads,
-                                    ndim, solvedim, dims, opts, 1);
+tridStatus_t tridDmtsvStridedBatchPaddedInc(
+    const double *a, const int *a_pads, const double *b, const int *b_pads,
+    const double *c, const int *c_pads, double *d, const int *d_pads, double *u,
+    const int *u_pads, int ndim, int solvedim, const int *dims, const int *opts,
+    int sync) {
+  tridMultiDimBatchSolve<double, 1>(a, a_pads, b, b_pads, c, c_pads, d, d_pads,
+                                    u, u_pads, ndim, solvedim, dims, opts, 1);
   return TRID_STATUS_SUCCESS;
 }
 
@@ -595,4 +593,4 @@ tridStatus_t tridDmtsvStridedBatchPaddedInc(const double *a, const int *a_pads,
 
 
 
-void initTridMultiDimBatchSolve(int ndim, int* dims, int* pads) { }
+// void initTridMultiDimBatchSolve(int ndim, int* dims, int* pads) { }

--- a/scalar/test/cuda_utils.hpp
+++ b/scalar/test/cuda_utils.hpp
@@ -10,8 +10,8 @@ template <typename T> class DeviceArray {
 public:
   DeviceArray();
   DeviceArray(size_t size);
-  DeviceArray(const T* host_arr, size_t size);
-  DeviceArray(const AlignedArray<T, 1> &host_arr);
+  DeviceArray(const T *host_arr, size_t size);
+  DeviceArray(const std::vector<T> &host_arr);
   DeviceArray(const DeviceArray &);
   DeviceArray &operator=(DeviceArray);
   DeviceArray(DeviceArray &&);
@@ -29,8 +29,8 @@ template <typename Float> class GPUMesh {
 
 public:
   GPUMesh(const MeshLoader<Float> &mesh);
-  GPUMesh(const AlignedArray<Float, 1> &a, const AlignedArray<Float, 1> &b,
-          const AlignedArray<Float, 1> &c, const AlignedArray<Float, 1> &d,
+  GPUMesh(const std::vector<Float> &a, const std::vector<Float> &b,
+          const std::vector<Float> &c, const std::vector<Float> &d,
           const std::vector<int> dims);
 
   const std::vector<int> &dims() const { return _dims; }
@@ -58,7 +58,7 @@ DeviceArray<T>::DeviceArray(const T *host_arr, size_t size)
 }
 
 template <typename T>
-DeviceArray<T>::DeviceArray(const AlignedArray<T, 1> &host_arr)
+DeviceArray<T>::DeviceArray(const std::vector<T> &host_arr)
     : DeviceArray(host_arr.data(), host_arr.size()) {}
 
 template <typename T>
@@ -79,8 +79,7 @@ DeviceArray<T> &DeviceArray<T>::operator=(DeviceArray<T> other) {
   std::swap(this->arr_d, other.arr_d);
 }
 template <typename T> DeviceArray<T>::~DeviceArray() {
-  if (arr_d)
-    cudaFree(arr_d);
+  if (arr_d) cudaFree(arr_d);
 }
 
 template <typename T> void DeviceArray<T>::allocate(size_t N) {
@@ -96,10 +95,10 @@ GPUMesh<Float>::GPUMesh(const MeshLoader<Float> &mesh)
     : GPUMesh<Float>(mesh.a(), mesh.b(), mesh.c(), mesh.d(), mesh.dims()) {}
 
 template <typename Float>
-GPUMesh<Float>::GPUMesh(const AlignedArray<Float, 1> &a,
-                        const AlignedArray<Float, 1> &b,
-                        const AlignedArray<Float, 1> &c,
-                        const AlignedArray<Float, 1> &d,
+GPUMesh<Float>::GPUMesh(const std::vector<Float> &a,
+                        const std::vector<Float> &b,
+                        const std::vector<Float> &c,
+                        const std::vector<Float> &d,
                         const std::vector<int> dims)
     : _a(a), _b(b), _c(c), _d(d), _dims(dims) {}
 

--- a/scalar/test/performance_test.cpp
+++ b/scalar/test/performance_test.cpp
@@ -18,7 +18,7 @@
 template <typename Float>
 void run_tridsolver(const MpiSolverParams &params,
                     const RandomMesh<Float> &mesh, int num_iters) {
-  AlignedArray<Float, 1> d(mesh.d());
+  std::vector<Float> d(mesh.d());
 
   // Dry run
   PROFILE_SUSPEND();

--- a/scalar/test/test_cpu.cpp
+++ b/scalar/test/test_cpu.cpp
@@ -170,8 +170,7 @@ void test_from_file_scalar_vec(const std::string &file_name) {
                                  d.data(), // d
                                  nullptr,  // u
                                  N,        // N
-                                 stride /
-                                     (SIMD_WIDTH / sizeof(Float))); // stride
+                                 stride);  // stride
 
   require_allclose(mesh.u().data(), d.data(), N, stride);
 }

--- a/scalar/test/test_cpu.cpp
+++ b/scalar/test/test_cpu.cpp
@@ -10,14 +10,14 @@
 template <typename Float>
 tridStatus_t tridStridedBatchWrapper(const Float *a, const Float *b,
                                      const Float *c, Float *d, Float *u,
-                                     int ndim, int solvedim, int *dims,
-                                     int *pads);
+                                     int ndim, int solvedim, const int *dims,
+                                     const int *pads);
 
 template <>
 tridStatus_t tridStridedBatchWrapper<float>(const float *a, const float *b,
                                             const float *c, float *d, float *u,
-                                            int ndim, int solvedim, int *dims,
-                                            int *pads) {
+                                            int ndim, int solvedim,
+                                            const int *dims, const int *pads) {
   return tridSmtsvStridedBatch(a, b, c, d, u, ndim, solvedim, dims, pads);
 }
 
@@ -25,7 +25,7 @@ template <>
 tridStatus_t tridStridedBatchWrapper<double>(const double *a, const double *b,
                                              const double *c, double *d,
                                              double *u, int ndim, int solvedim,
-                                             int *dims, int *pads) {
+                                             const int *dims, const int *pads) {
   return tridDmtsvStridedBatch(a, b, c, d, u, ndim, solvedim, dims, pads);
 }
 
@@ -66,32 +66,72 @@ void trid_scalar_vec_wrapper<double>(const double *a, const double *b,
 
 template <typename Float> void test_from_file(const std::string &file_name) {
   MeshLoader<Float> mesh(file_name);
-  AlignedArray<Float, 1> d(mesh.d());
-  std::vector<int> dims = mesh.dims(); // Because it isn't const in the lib
-  // Fix num_dims workaround
-  while (dims.size() < 3) {
-    dims.push_back(1);
-  }
+  std::vector<Float> d(mesh.d());
 
   const tridStatus_t status =
-      tridStridedBatchWrapper<Float>(mesh.a().data(),    // a
-                                     mesh.b().data(),    // b
-                                     mesh.c().data(),    // c
-                                     d.data(),           // d
-                                     nullptr,            // u
-                                     mesh.dims().size(), // ndim
-                                     mesh.solve_dim(),   // solvedim
-                                     dims.data(),        // dims
-                                     dims.data());       // pads
+      tridStridedBatchWrapper<Float>(mesh.a().data(),     // a
+                                     mesh.b().data(),     // b
+                                     mesh.c().data(),     // c
+                                     d.data(),            // d
+                                     nullptr,             // u
+                                     mesh.dims().size(),  // ndim
+                                     mesh.solve_dim(),    // solvedim
+                                     mesh.dims().data(),  // dims
+                                     mesh.dims().data()); // pads
 
   CHECK(status == TRID_STATUS_SUCCESS);
   require_allclose(mesh.u(), d);
 }
 
 template <typename Float>
+void test_from_file_padded(const std::string &file_name) {
+  MeshLoader<Float> mesh(file_name);
+
+  std::vector<int> padded_dims = mesh.dims();
+  int padded_size              = 1;
+  for (size_t i = 0; i < padded_dims.size(); i++) {
+    padded_dims[i] += 2;
+    padded_size *= padded_dims[i];
+  }
+
+  std::vector<Float> a_p(padded_size);
+  std::vector<Float> b_p(padded_size);
+  std::vector<Float> c_p(padded_size);
+  std::vector<Float> d_p(padded_size);
+  std::vector<Float> u_p(padded_size);
+
+  copy_to_padded_array(mesh.a(), a_p, mesh.dims());
+  copy_to_padded_array(mesh.b(), b_p, mesh.dims());
+  copy_to_padded_array(mesh.c(), c_p, mesh.dims());
+  copy_to_padded_array(mesh.d(), d_p, mesh.dims());
+  copy_to_padded_array(mesh.u(), u_p, mesh.dims());
+
+  int offset_to_first_element = 1;
+  for (size_t i = 0; i < padded_dims.size() - 1; ++i) {
+    offset_to_first_element +=
+        std::accumulate(padded_dims.begin(), padded_dims.begin() + i + 1, 1,
+                        std::multiplies<int>());
+  }
+
+  const tridStatus_t status =
+      tridStridedBatchWrapper<Float>(a_p.data() + offset_to_first_element, // a
+                                     b_p.data() + offset_to_first_element, // b
+                                     c_p.data() + offset_to_first_element, // c
+                                     d_p.data() + offset_to_first_element, // d
+                                     nullptr,                              // u
+                                     mesh.dims().size(),  // ndim
+                                     mesh.solve_dim(),    // solvedim
+                                     mesh.dims().data(),  // dims
+                                     padded_dims.data()); // pads
+
+  CHECK(status == TRID_STATUS_SUCCESS);
+  require_allclose(u_p, d_p);
+}
+
+template <typename Float>
 void test_from_file_scalar(const std::string &file_name) {
   MeshLoader<Float> mesh(file_name);
-  AlignedArray<Float, 1> d(mesh.d());
+  std::vector<Float> d(mesh.d());
 
   int stride = 1;
   for (size_t i = 0; i < mesh.solve_dim(); ++i) {
@@ -112,7 +152,10 @@ void test_from_file_scalar(const std::string &file_name) {
 
 template <typename Float>
 void test_from_file_scalar_vec(const std::string &file_name) {
-  MeshLoader<Float, SIMD_WIDTH> mesh(file_name);
+  MeshLoader<Float> mesh(file_name);
+  AlignedArray<Float, SIMD_WIDTH> a(mesh.a());
+  AlignedArray<Float, SIMD_WIDTH> b(mesh.b());
+  AlignedArray<Float, SIMD_WIDTH> c(mesh.c());
   AlignedArray<Float, SIMD_WIDTH> d(mesh.d());
 
   int stride = 1;
@@ -121,16 +164,16 @@ void test_from_file_scalar_vec(const std::string &file_name) {
   }
   const size_t N = mesh.dims()[mesh.solve_dim()];
 
-  trid_scalar_vec_wrapper<Float>(mesh.a().data(), // a
-                                 mesh.b().data(), // b
-                                 mesh.c().data(), // c
-                                 d.data(),        // d
-                                 nullptr,         // u
-                                 N,               // N
+  trid_scalar_vec_wrapper<Float>(a.data(), // a
+                                 b.data(), // b
+                                 c.data(), // c
+                                 d.data(), // d
+                                 nullptr,  // u
+                                 N,        // N
                                  stride /
                                      (SIMD_WIDTH / sizeof(Float))); // stride
 
-  require_allclose(mesh.u(), d, N, stride);
+  require_allclose(mesh.u().data(), d.data(), N, stride);
 }
 
 TEST_CASE("cpu: strided batch small", "[small]") {
@@ -253,6 +296,61 @@ TEMPLATE_TEST_CASE("cpu: trid_scalar_vec large", "[large]", double, float) {
     }
     SECTION("solvedim: 2") {
       test_from_file_scalar_vec<TestType>("files/three_dim_large_solve2");
+    }
+  }
+}
+
+TEST_CASE("cpu: strided batch small padded", "[small][padded]") {
+  SECTION("double") {
+    SECTION("ndims: 1") {
+      test_from_file_padded<double>("files/one_dim_small");
+    }
+    SECTION("ndims: 2") {
+      SECTION("solvedim: 0") {
+        test_from_file_padded<double>("files/two_dim_small_solve0");
+      }
+      SECTION("solvedim: 1") {
+        test_from_file_padded<double>("files/two_dim_small_solve1");
+      }
+    }
+  }
+  SECTION("float") {
+    SECTION("ndims: 1") { test_from_file_padded<float>("files/one_dim_small"); }
+    SECTION("ndims: 2") {
+      SECTION("solvedim: 0") {
+        test_from_file_padded<float>("files/two_dim_small_solve0");
+      }
+      // This won't work because the array size is 8 and we don't test with
+      // padding at the end yet
+      /* SECTION("solvedim: 1") { */
+      /*  test_from_file<float>("files/two_dim_small_solve1"); */
+      /* } */
+    }
+  }
+}
+
+TEMPLATE_TEST_CASE("cpu: solver large padded", "[large][padded]", double,
+                   float) {
+  SECTION("ndims: 1") {
+    test_from_file_padded<TestType>("files/one_dim_large");
+  }
+  SECTION("ndims: 2") {
+    SECTION("solvedim: 0") {
+      test_from_file_padded<TestType>("files/two_dim_large_solve0");
+    }
+    SECTION("solvedim: 1") {
+      test_from_file_padded<TestType>("files/two_dim_large_solve1");
+    }
+  }
+  SECTION("ndims: 3") {
+    SECTION("solvedim: 0") {
+      test_from_file_padded<TestType>("files/three_dim_large_solve0");
+    }
+    SECTION("solvedim: 1") {
+      test_from_file_padded<TestType>("files/three_dim_large_solve1");
+    }
+    SECTION("solvedim: 2") {
+      test_from_file_padded<TestType>("files/three_dim_large_solve2");
     }
   }
 }

--- a/scalar/test/test_cuda.cu
+++ b/scalar/test/test_cuda.cu
@@ -15,7 +15,7 @@ tridStatus_t tridStridedBatchWrapper<float>(const float *a, const float *b,
                                             const float *c, float *d, float *u,
                                             int ndim, int solvedim, int *dims,
                                             int *pads) {
-  int opts[] = {0, 0, 0};
+  int opts[] = {ndim == 1 ? 1 : 0, 0, 0};
   return tridSmtsvStridedBatch(a, b, c, d, u, ndim, solvedim, dims, pads, opts,
                                0);
 }
@@ -25,7 +25,7 @@ tridStatus_t tridStridedBatchWrapper<double>(const double *a, const double *b,
                                              const double *c, double *d,
                                              double *u, int ndim, int solvedim,
                                              int *dims, int *pads) {
-  int opts[] = {0, 0, 0};
+  int opts[] = {ndim == 1 ? 1 : 0, 0, 0};
   return tridDmtsvStridedBatch(a, b, c, d, u, ndim, solvedim, dims, pads, opts,
                                0);
 }
@@ -146,6 +146,17 @@ TEMPLATE_TEST_CASE("cuda: solveZ", "[solvedim:2]", double, float) {
 }
 
 TEMPLATE_TEST_CASE("cuda: padded", "[padded]", double, float) {
+  SECTION("ndims: 1") {
+    test_from_file_padded<TestType>("files/one_dim_large");
+  }
+  SECTION("ndims: 2") {
+    SECTION("solvedim: 0") {
+      test_from_file_padded<TestType>("files/two_dim_large_solve0");
+    }
+    SECTION("solvedim: 1") {
+      test_from_file_padded<TestType>("files/two_dim_large_solve1");
+    }
+  }
   SECTION("ndims: 3") {
     SECTION("solvedim: 0") {
       test_from_file_padded<TestType>("files/three_dim_large_solve0");

--- a/scalar/test/test_cuda.cu
+++ b/scalar/test/test_cuda.cu
@@ -51,7 +51,7 @@ template <typename Float> void test_from_file(const std::string &file_name) {
 
   CHECK(status == TRID_STATUS_SUCCESS);
 
-  AlignedArray<Float, 1> d(mesh.d());
+  std::vector<Float> d(mesh.d().size());
   cudaMemcpy(d.data(), device_mesh.d().data(), d.size() * sizeof(Float),
              cudaMemcpyDeviceToHost);
   require_allclose(mesh.u(), d);
@@ -116,7 +116,7 @@ void test_from_file_padded(const std::string &file_name) {
   cudaFree(b_d);
   cudaFree(c_d);
   cudaFree(d_d);
-  require_allclose_padded(u, d);
+  require_allclose(u, d);
 }
 
 TEMPLATE_TEST_CASE("cuda: solveX", "[solvedim:0]", double, float) {

--- a/scalar/test/test_cuda_mpi.cu
+++ b/scalar/test/test_cuda_mpi.cu
@@ -181,8 +181,12 @@ void test_solver_from_file_padded(const std::string &file_name) {
   copy_to_padded_array(d, d_p, local_sizes);
   copy_to_padded_array(u, u_p, local_sizes);
 
-  int offset_to_first_element =
-      padded_dims[1] * padded_dims[0] + padded_dims[0] + 1;
+  int offset_to_first_element = 1;
+  for (size_t i = 0; i < padded_dims.size() - 1; ++i) {
+    offset_to_first_element +=
+        std::accumulate(padded_dims.begin(), padded_dims.begin() + i + 1, 1,
+                        std::multiplies<int>());
+  }
 
   Float *a_d, *b_d, *c_d, *d_d, *u_d;
   cudaMalloc((void **)&a_d, padded_size * sizeof(Float));
@@ -376,6 +380,20 @@ TEMPLATE_TEST_CASE_SIG("cuda: padded", "[padded]",
                          MpiSolverParams::MPICommStrategy strategy),
                         TestType, INC, strategy),
                        PARAM_COMBOS) {
+  SECTION("ndims: 1") {
+    test_solver_from_file_padded<TestType, INC, strategy>(
+        "files/one_dim_large");
+  }
+  SECTION("ndims: 2") {
+    SECTION("solvedim: 0") {
+      test_solver_from_file_padded<TestType, INC, strategy>(
+          "files/two_dim_large_solve0");
+    }
+    SECTION("solvedim: 1") {
+      test_solver_from_file_padded<TestType, INC, strategy>(
+          "files/two_dim_large_solve1");
+    }
+  }
   SECTION("ndims: 3") {
     SECTION("solvedim: 0") {
       test_solver_from_file_padded<TestType, INC, strategy>(


### PR DESCRIPTION
Hi!
This branch contains some improvements on the API, extending the testing and fix some bugs.

API:
dims, pads, and opts parameters in single node CPU and single node CUDA libs are taken as const int *, it's more consistent and we don't change those.

CUDA: void initTridMultiDimBatchSolve(int ndim, int *dims, int *pads); is removed (the implementation was an empty function body)

Tests:
Added tests for padded systems for 1D and 2D problems for CPU+MPI, CUDA+MPI, and for 1-3D problems for single node CPU and single node CUDA. (Single node CPU fails on the tests at this point, since Y and Z solve assumes the stride to be divisible with SIMD_WIDTH.)
Use std::vector instead of AlignedArrays in MeshLoader: We tested alignment only for trid_scalar_vec. 

Bug Fixes:
CPU+MPI Jacobi: fix the issue if run with a single MPI process where rank 0 would skip Jacobi iterations and 0 would be written to d_0.
CPU+MPI PCR: fix MPI waits. Each process waits for sends to complete before writing the result of the next iteration to the buffer.