### PR TITLE
Fix/ops padding

### DIFF
--- a/apps/adi/src/adi_cpu.cpp
+++ b/apps/adi/src/adi_cpu.cpp
@@ -233,9 +233,9 @@ int main(int argc, char* argv[]) {
 
     int solvedim = 0;   // user chosen dimension for which the solution is performed
     #if FPPREC == 0
-      tridSmtsvStridedBatch(nullptr, h_ax, h_bx, h_cx, h_du, h_u, ndim, solvedim, dims, pads);
+      tridSmtsvStridedBatch(nullptr, h_ax, h_bx, h_cx, h_du, ndim, solvedim, dims, pads);
     #elif FPPREC == 1
-      tridDmtsvStridedBatch(nullptr, h_ax, h_bx, h_cx, h_du, h_u, ndim, solvedim, dims, pads);
+      tridDmtsvStridedBatch(nullptr, h_ax, h_bx, h_cx, h_du, ndim, solvedim, dims, pads);
     #endif
 
     timing_end(prof, &timer, &elapsed_trid_x, "trid_x");
@@ -247,9 +247,9 @@ int main(int argc, char* argv[]) {
 
     solvedim = 1;   // user chosen dimension for which the solution is performed
     #if FPPREC == 0
-      tridSmtsvStridedBatch(nullptr, h_ay, h_by, h_cy, h_du, h_u, ndim, solvedim, dims, pads);
+      tridSmtsvStridedBatch(nullptr, h_ay, h_by, h_cy, h_du, ndim, solvedim, dims, pads);
     #elif FPPREC == 1
-      tridDmtsvStridedBatch(nullptr, h_ay, h_by, h_cy, h_du, h_u, ndim, solvedim, dims, pads);
+      tridDmtsvStridedBatch(nullptr, h_ay, h_by, h_cy, h_du, ndim, solvedim, dims, pads);
     #endif
 
     timing_end(prof, &timer, &elapsed_trid_y, "trid_y");

--- a/apps/adi/src/adi_cuda.cu
+++ b/apps/adi/src/adi_cuda.cu
@@ -291,9 +291,9 @@ int main(int argc, char* argv[]) {
       solvedim = 0;
       //tridMultiDimBatchSolve<FP,0>(d_ax, d_bx, d_cx, d_du, d_u, ndim, solvedim, dims, pads, opts, sync);
       #if FPPREC==0
-        tridSmtsvStridedBatch(&trid_params, d_ax, d_bx, d_cx, d_du, d_u, ndim, solvedim, dims, pads);
+        tridSmtsvStridedBatch(&trid_params, d_ax, d_bx, d_cx, d_du, ndim, solvedim, dims, pads);
       #elif FPPREC==1
-        tridDmtsvStridedBatch(&trid_params, d_ax, d_bx, d_cx, d_du, d_u, ndim, solvedim, dims, pads);
+        tridDmtsvStridedBatch(&trid_params, d_ax, d_bx, d_cx, d_du, ndim, solvedim, dims, pads);
       #endif
     timing_end(prof,&timer,&elapsed_trid_x,"trid_x");
 
@@ -303,9 +303,9 @@ int main(int argc, char* argv[]) {
       //else           tridMultiDimBatchSolve<FP,0>(d_ay, d_by, d_cy, d_du, d_u, ndim, solvedim, dims, pads, opts, &d_buffer, sync);
       //tridMultiDimBatchSolve<FP,0>(d_ay, d_by, d_cy, d_du, d_u, ndim, solvedim, dims, pads, opts, sync);
       #if FPPREC==0
-        tridSmtsvStridedBatch(&trid_params, d_ay, d_by, d_cy, d_du, d_u, ndim, solvedim, dims, pads);
+        tridSmtsvStridedBatch(&trid_params, d_ay, d_by, d_cy, d_du, ndim, solvedim, dims, pads);
       #elif FPPREC==1
-        tridDmtsvStridedBatch(&trid_params, d_ay, d_by, d_cy, d_du, d_u, ndim, solvedim, dims, pads);
+        tridDmtsvStridedBatch(&trid_params, d_ay, d_by, d_cy, d_du, ndim, solvedim, dims, pads);
       #endif
     timing_end(prof,&timer,&elapsed_trid_y,"trid_y");
 

--- a/apps/adi/src/adi_mpi_cpu.cpp
+++ b/apps/adi/src/adi_mpi_cpu.cpp
@@ -249,6 +249,16 @@ int init(app_handle &app, preproc_handle<FP> &pre_handle, int &iter, int argc, c
       app.params_y = new MpiSolverParams(app.comm, 3, app.pdims, by, MpiSolverParams::LATENCY_HIDING_INTERLEAVED);
       app.params_z = new MpiSolverParams(app.comm, 3, app.pdims, bz, MpiSolverParams::LATENCY_HIDING_INTERLEAVED);
       break;
+    case 4:
+      app.params_x = new MpiSolverParams(app.comm, 3, app.pdims, bx, MpiSolverParams::JACOBI);
+      app.params_y = new MpiSolverParams(app.comm, 3, app.pdims, by, MpiSolverParams::JACOBI);
+      app.params_z = new MpiSolverParams(app.comm, 3, app.pdims, bz, MpiSolverParams::JACOBI);
+      break;
+    case 5:
+      app.params_x = new MpiSolverParams(app.comm, 3, app.pdims, bx, MpiSolverParams::PCR);
+      app.params_y = new MpiSolverParams(app.comm, 3, app.pdims, by, MpiSolverParams::PCR);
+      app.params_z = new MpiSolverParams(app.comm, 3, app.pdims, bz, MpiSolverParams::PCR);
+      break;
     default:
       exit(-1);
   }
@@ -419,9 +429,9 @@ int main(int argc, char* argv[]) {
     //
     timing_start(&timer);
 #if FPPREC == 0
-    tridSmtsvStridedBatch(&trid_params_x, app.a, app.b, app.c, app.d, app.u, 3, 0, app.size, app.pads);
+    tridSmtsvStridedBatch(&trid_params_x, app.a, app.b, app.c, app.d, 3, 0, app.size, app.pads);
 #else
-    tridDmtsvStridedBatch(&trid_params_x, app.a, app.b, app.c, app.d, app.u, 3, 0, app.size, app.pads);
+    tridDmtsvStridedBatch(&trid_params_x, app.a, app.b, app.c, app.d, 3, 0, app.size, app.pads);
 #endif
     timing_end(&timer, &elapsed_trid_x);
 
@@ -430,9 +440,9 @@ int main(int argc, char* argv[]) {
     //
     timing_start(&timer);
 #if FPPREC == 0
-    tridSmtsvStridedBatch(&trid_params_y, app.a, app.b, app.c, app.d, app.u, 3, 1, app.size, app.pads);
+    tridSmtsvStridedBatch(&trid_params_y, app.a, app.b, app.c, app.d, 3, 1, app.size, app.pads);
 #else
-    tridDmtsvStridedBatch(&trid_params_y, app.a, app.b, app.c, app.d, app.u, 3, 1, app.size, app.pads);
+    tridDmtsvStridedBatch(&trid_params_y, app.a, app.b, app.c, app.d, 3, 1, app.size, app.pads);
 #endif
     timing_end(&timer, &elapsed_trid_y);
 

--- a/apps/adi/src/adi_mpi_cuda.cu
+++ b/apps/adi/src/adi_mpi_cuda.cu
@@ -225,6 +225,12 @@ int init(app_handle &app, preproc_handle<FP> &pre_handle, int &iter, int argc, c
     case 3:
       app.params = new MpiSolverParams(app.comm, 3, app.pdims, batchSize, MpiSolverParams::LATENCY_HIDING_INTERLEAVED);
       break;
+    case 4:
+      app.params = new MpiSolverParams(app.comm, 3, app.pdims, batchSize, MpiSolverParams::JACOBI);
+      break;
+    case 5:
+      app.params = new MpiSolverParams(app.comm, 3, app.pdims, batchSize, MpiSolverParams::PCR);
+      break;
     default:
       exit(-1);
   }
@@ -369,9 +375,9 @@ int main(int argc, char* argv[]) {
     //
     timing_start(&timer);
 #if FPPREC == 0
-    tridSmtsvStridedBatch(&trid_params, app.a, app.b, app.c, app.d, app.u, 3, 0, app.size, app.size);
+    tridSmtsvStridedBatch(&trid_params, app.a, app.b, app.c, app.d, 3, 0, app.size, app.size);
 #else
-    tridDmtsvStridedBatch(&trid_params, app.a, app.b, app.c, app.d, app.u, 3, 0, app.size, app.size);
+    tridDmtsvStridedBatch(&trid_params, app.a, app.b, app.c, app.d, 3, 0, app.size, app.size);
 #endif
 
     timing_end(&timer, &elapsed_trid_x);
@@ -381,9 +387,9 @@ int main(int argc, char* argv[]) {
     //
     timing_start(&timer);
 #if FPPREC == 0
-    tridSmtsvStridedBatch(&trid_params, app.a, app.b, app.c, app.d, app.u, 3, 1, app.size, app.size);
+    tridSmtsvStridedBatch(&trid_params, app.a, app.b, app.c, app.d, 3, 1, app.size, app.size);
 #else
-    tridDmtsvStridedBatch(&trid_params, app.a, app.b, app.c, app.d, app.u, 3, 1, app.size, app.size);
+    tridDmtsvStridedBatch(&trid_params, app.a, app.b, app.c, app.d, 3, 1, app.size, app.size);
 #endif
     timing_end(&timer, &elapsed_trid_y);
 

--- a/scalar/include/trid_cpu.h
+++ b/scalar/include/trid_cpu.h
@@ -39,26 +39,25 @@
 
 EXTERN_C
 void trid_scalarS(const float *a, const float *b, const float *c, float *d,
-                  float *u, int N, int stride);
+                  int N, int stride);
 EXTERN_C
 void trid_x_transposeS(const float *a, const float *b, const float *c, float *d,
-                       float *u, int sys_size, int sys_pad, int stride);
+                       int sys_size, int sys_pad, int stride);
 EXTERN_C
 void trid_scalar_vecS(const float *a, const float *b, const float *c, float *d,
-                      float *u, int N, int stride);
+                      int N, int stride);
 EXTERN_C
 void trid_scalar_vecSInc(const float *a, const float *b, const float *c,
                          float *d, float *u, int N, int stride);
 EXTERN_C
 void trid_scalarD(const double *a, const double *b, const double *c, double *d,
-                  double *u, int N, int stride);
+                  int N, int stride);
 EXTERN_C
 void trid_x_transposeD(const double *a, const double *b, const double *c,
-                       double *d, double *u, int sys_size, int sys_pad,
-                       int stride);
+                       double *d, int sys_size, int sys_pad, int stride);
 EXTERN_C
 void trid_scalar_vecD(const double *a, const double *b, const double *c,
-                      double *d, double *u, int N, int stride);
+                      double *d, int N, int stride);
 EXTERN_C
 void trid_scalar_vecDInc(const double *a, const double *b, const double *c,
                          double *d, double *u, int N, int stride);

--- a/scalar/include/tridsolver.h
+++ b/scalar/include/tridsolver.h
@@ -34,18 +34,18 @@
 // specifies any padding used in the arrays (the total length of each dimension
 // including padding).
 //
-// The result is written to 'd'. 'u' is unused.
+// The result is written to 'd'.
 EXTERN_C
 tridStatus_t tridDmtsvStridedBatch(const TridParams *ctx, const double *a,
                                    const double *b, const double *c, double *d,
-                                   double *u, int ndim, int solvedim,
-                                   const int *dims, const int *pads);
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *pads);
 
 EXTERN_C
 tridStatus_t tridSmtsvStridedBatch(const TridParams *ctx, const float *a,
                                    const float *b, const float *c, float *d,
-                                   float *u, int ndim, int solvedim,
-                                   const int *dims, const int *pads);
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *pads);
 
 // Solve a batch of tridiagonal systems along a specified axis ('solvedim').
 // 'a', 'b', 'c', 'd' are the parameters of the tridiagonal systems which must

--- a/scalar/src/cpu/trid_cpu.cpp
+++ b/scalar/src/cpu/trid_cpu.cpp
@@ -178,7 +178,6 @@ void trid_x_transpose(const REAL *__restrict a, const REAL *__restrict b,
     // perform a noncomplete forward
     // Loads are safe since sys_pads must be a multiple of SIMD_WIDTH, and we
     // don't use data in paddings
-    assert(sys_pad % SIMD_VEC == 0);
 
     int n = ROUND_DOWN(sys_size, SIMD_VEC);
     LOAD(a_reg, a, n, sys_pad);
@@ -203,7 +202,7 @@ void trid_x_transpose(const REAL *__restrict a, const REAL *__restrict b,
   }
 
   // backward on last chunk
-  int n = ROUND_DOWN(sys_size, sys_pad);
+  int n = ROUND_DOWN(sys_size, SIMD_VEC);
   if (sys_size != sys_pad) {
     d_reg[sys_size - 1 - n] = dd;
     for (int i = sys_size - n - 2; i >= 0; i--) {
@@ -212,7 +211,7 @@ void trid_x_transpose(const REAL *__restrict a, const REAL *__restrict b,
     }
     if (INC) {
       LOAD(u_reg, u, n, sys_pad);
-      for (int j = 0; j < sys_size; j++)
+      for (int j = 0; j < sys_size - n; j++)
         u_reg[j] = SIMD_ADD_P(u_reg[j], d_reg[j]);
       STORE(u, u_reg, n, sys_pad);
     } else {

--- a/scalar/src/cpu/trid_cpu.cpp
+++ b/scalar/src/cpu/trid_cpu.cpp
@@ -458,10 +458,10 @@ void tridMultiDimBatchSolve(const REAL *a, const REAL *b, const REAL *c,
 
 tridStatus_t tridSmtsvStridedBatch(const TridParams *, const float *a,
                                    const float *b, const float *c, float *d,
-                                   float *u, int ndim, int solvedim,
-                                   const int *dims, const int *pads) {
-  tridMultiDimBatchSolve<float, false>(a, b, c, d, u, ndim, solvedim, dims,
-                                       pads);
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *pads) {
+  tridMultiDimBatchSolve<float, false>(a, b, c, d, nullptr, ndim, solvedim,
+                                       dims, pads);
   return TRID_STATUS_SUCCESS;
 }
 
@@ -476,23 +476,23 @@ tridStatus_t tridSmtsvStridedBatchInc(const TridParams *, const float *a,
 
 void trid_scalarS(const float *__restrict a, const float *__restrict b,
                   const float *__restrict c, float *__restrict d,
-                  float *__restrict u, int N, int stride) {
+                  int N, int stride) {
 
-  trid_scalar<float, false>(a, b, c, d, u, N, stride);
+  trid_scalar<float, false>(a, b, c, d, nullptr, N, stride);
 }
 
 void trid_x_transposeS(const float *__restrict a, const float *__restrict b,
                        const float *__restrict c, float *__restrict d,
-                       float *__restrict u, int sys_size, int sys_pad) {
+                       int sys_size, int sys_pad) {
 
-  trid_x_transpose<float, false>(a, b, c, d, u, sys_size, sys_pad);
+  trid_x_transpose<float, false>(a, b, c, d, nullptr, sys_size, sys_pad);
 }
 
 void trid_scalar_vecS(const float *__restrict a, const float *__restrict b,
                       const float *__restrict c, float *__restrict d,
-                      float *__restrict u, int N, int stride) {
+                      int N, int stride) {
 
-  trid_scalar_vec<FP, VECTOR, false>(a, b, c, d, u, N, stride);
+  trid_scalar_vec<FP, VECTOR, false>(a, b, c, d, nullptr, N, stride);
 }
 
 void trid_scalar_vecSInc(const float *__restrict a, const float *__restrict b,
@@ -506,10 +506,10 @@ void trid_scalar_vecSInc(const float *__restrict a, const float *__restrict b,
 
 tridStatus_t tridDmtsvStridedBatch(const TridParams *, const double *a,
                                    const double *b, const double *c, double *d,
-                                   double *u, int ndim, int solvedim,
-                                   const int *dims, const int *pads) {
-  tridMultiDimBatchSolve<double, false>(a, b, c, d, u, ndim, solvedim, dims,
-                                        pads);
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *pads) {
+  tridMultiDimBatchSolve<double, false>(a, b, c, d, nullptr, ndim, solvedim,
+                                        dims, pads);
   return TRID_STATUS_SUCCESS;
 }
 
@@ -525,23 +525,23 @@ tridStatus_t tridDmtsvStridedBatchInc(const TridParams *, const double *a,
 
 void trid_scalarD(const double *__restrict a, const double *__restrict b,
                   const double *__restrict c, double *__restrict d,
-                  double *__restrict u, int N, int stride) {
+                  int N, int stride) {
 
-  trid_scalar<double, false>(a, b, c, d, u, N, stride);
+  trid_scalar<double, false>(a, b, c, d, nullptr, N, stride);
 }
 
 void trid_x_transposeD(const double *__restrict a, const double *__restrict b,
                        const double *__restrict c, double *__restrict d,
-                       double *__restrict u, int sys_size, int sys_pad) {
+                       int sys_size, int sys_pad) {
 
-  trid_x_transpose<double, false>(a, b, c, d, u, sys_size, sys_pad);
+  trid_x_transpose<double, false>(a, b, c, d, nullptr, sys_size, sys_pad);
 }
 
 void trid_scalar_vecD(const double *__restrict a, const double *__restrict b,
                       const double *__restrict c, double *__restrict d,
-                      double *__restrict u, int N, int stride) {
+                      int N, int stride) {
 
-  trid_scalar_vec<FP, VECTOR, false>(a, b, c, d, u, N, stride);
+  trid_scalar_vec<FP, VECTOR, false>(a, b, c, d, nullptr, N, stride);
 }
 
 void trid_scalar_vecDInc(const double *__restrict a, const double *__restrict b,

--- a/scalar/src/cpu/trid_mpi_cpu.cpp
+++ b/scalar/src/cpu/trid_mpi_cpu.cpp
@@ -1468,24 +1468,24 @@ void tridMultiDimBatchSolve(const MpiSolverParams *params, const REAL *a,
 // specifies any padding used in the arrays (the total length of each
 // dimension including padding).
 //
-// The result is written to 'd'. 'u' is unused.
+// The result is written to 'd'.
 
 #if FPPREC == 1
 tridStatus_t tridDmtsvStridedBatch(const TridParams *ctx, const double *a,
                                    const double *b, const double *c, double *d,
-                                   double *u, int ndim, int solvedim,
-                                   const int *dims, const int *pads) {
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *pads) {
   tridMultiDimBatchSolve<double, 0>((MpiSolverParams *)ctx->mpi_params, a, b, c,
-                                    d, u, ndim, solvedim, dims, pads);
+                                    d, nullptr, ndim, solvedim, dims, pads);
   return TRID_STATUS_SUCCESS;
 }
 #else
 tridStatus_t tridSmtsvStridedBatch(const TridParams *ctx, const float *a,
                                    const float *b, const float *c, float *d,
-                                   float *u, int ndim, int solvedim,
-                                   const int *dims, const int *pads) {
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *pads) {
   tridMultiDimBatchSolve<float, 0>((MpiSolverParams *)ctx->mpi_params, a, b, c,
-                                   d, u, ndim, solvedim, dims, pads);
+                                   d, nullptr, ndim, solvedim, dims, pads);
   return TRID_STATUS_SUCCESS;
 }
 #endif

--- a/scalar/src/cuda/trid_cuda.cu
+++ b/scalar/src/cuda/trid_cuda.cu
@@ -418,8 +418,8 @@ void tridMultiDimBatchSolve(const REAL *d_a, const int *a_pads, const REAL *d_b,
 
 tridStatus_t tridSmtsvStridedBatch(const TridParams *ctx, const float *a,
                                    const float *b, const float *c, float *d,
-                                   float *u, int ndim, int solvedim,
-                                   const int *dims, const int *pads) {
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *pads) {
   tridMultiDimBatchSolve<float, 0>(a, pads, b, pads, c, pads, d, pads, NULL,
                                    pads, ndim, solvedim, dims, ctx->opts, 1);
   return TRID_STATUS_SUCCESS;
@@ -427,8 +427,8 @@ tridStatus_t tridSmtsvStridedBatch(const TridParams *ctx, const float *a,
 
 tridStatus_t tridDmtsvStridedBatch(const TridParams *ctx, const double *a,
                                    const double *b, const double *c, double *d,
-                                   double *u, int ndim, int solvedim,
-                                   const int *dims, const int *pads) {
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *pads) {
   tridMultiDimBatchSolve<double, 0>(a, pads, b, pads, c, pads, d, pads, NULL,
                                     pads, ndim, solvedim, dims, ctx->opts, 1);
   return TRID_STATUS_SUCCESS;

--- a/scalar/src/cuda/trid_cuda_mpi.cu
+++ b/scalar/src/cuda/trid_cuda_mpi.cu
@@ -769,22 +769,24 @@ void tridMultiDimBatchSolveMPI(const MpiSolverParams *params, const REAL *a,
 // specifies any padding used in the arrays (the total length of each dimension
 // including padding).
 //
-// The result is written to 'd'. 'u' is unused.
+// The result is written to 'd'.
 tridStatus_t tridDmtsvStridedBatch(const TridParams *ctx, const double *a,
                                    const double *b, const double *c, double *d,
-                                   double *u, int ndim, int solvedim,
-                                   const int *dims, const int *pads) {
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *pads) {
   tridMultiDimBatchSolveMPI<double, 0>((MpiSolverParams *)ctx->mpi_params, a, b,
-                                       c, d, u, ndim, solvedim, dims, pads);
+                                       c, d, nullptr, ndim, solvedim, dims,
+                                       pads);
   return TRID_STATUS_SUCCESS;
 }
 
 tridStatus_t tridSmtsvStridedBatch(const TridParams *ctx, const float *a,
                                    const float *b, const float *c, float *d,
-                                   float *u, int ndim, int solvedim,
-                                   const int *dims, const int *pads) {
+                                   int ndim, int solvedim, const int *dims,
+                                   const int *pads) {
   tridMultiDimBatchSolveMPI<float, 0>((MpiSolverParams *)ctx->mpi_params, a, b,
-                                      c, d, u, ndim, solvedim, dims, pads);
+                                      c, d, nullptr, ndim, solvedim, dims,
+                                      pads);
   return TRID_STATUS_SUCCESS;
 }
 

--- a/scalar/src/cuda/trid_iterative_mpi.hpp
+++ b/scalar/src/cuda/trid_iterative_mpi.hpp
@@ -830,7 +830,7 @@ __global__ void trid_linear_backward_pass_unaligned(
       int ind_floor = ((ind + offset) / align<REAL>)*align<REAL> - offset;
       int sys_off   = ind - ind_floor;
       int end_remainder =
-          ((sys_size - offset) / vec_length<REAL>) * vec_length<REAL> - sys_off;
+          sys_size / vec_length<REAL> * vec_length<REAL> - sys_off;
 
       if (!padded_sys && end_remainder < sys_size) {
         // i = n-1
@@ -867,7 +867,7 @@ __global__ void trid_linear_backward_pass_unaligned(
 
         if (!padded_sys) {
           for (int i = vec_length<REAL> - 1; i >= 0; i--) {
-            if (n + i == sys_size - 1) {
+            if (n + i - sys_off == sys_size - 1) {
               if (rank != nproc - 1)
                 dd_p1 = l_d.f[i] - dd_p1 * l_cc.f[i];
               else

--- a/scalar/src/cuda/trid_iterative_mpi.hpp
+++ b/scalar/src/cuda/trid_iterative_mpi.hpp
@@ -190,21 +190,24 @@ __global__ void trid_linear_forward_pass_aligned(
       REAL b_0 = l_b.f[0];
       REAL c_0 = l_c.f[0];
       REAL d_0 = l_d.f[0];
-      // i = 1
-      forward_linear_process_row1<REAL, shift_c0_on_rank0>(
-          l_a.f[1], a_m1, l_b.f[1], l_c.f[1], c_m1, l_d.f[1], d_m1, b_0, c_0,
-          d_0, sys_size, rank, nproc);
-      l_d.f[1]  = d_m1;
-      l_aa.f[1] = a_m1;
-      l_cc.f[1] = c_m1;
 
-      for (int i = 2; i < vec_length<REAL>; i++) {
-        forward_linear_process_line<REAL, shift_c0_on_rank0>(
-            l_a.f[i], a_m1, l_b.f[i], l_c.f[i], c_m1, l_d.f[i], d_m1, b_0, c_0,
-            d_0, sys_size, n + i, rank, nproc);
-        l_d.f[i]  = d_m1;
-        l_aa.f[i] = a_m1;
-        l_cc.f[i] = c_m1;
+      if(!padded_sys) {
+        // i = 1
+        forward_linear_process_row1<REAL, shift_c0_on_rank0>(
+            l_a.f[1], a_m1, l_b.f[1], l_c.f[1], c_m1, l_d.f[1], d_m1, b_0, c_0,
+            d_0, sys_size, rank, nproc);
+        l_d.f[1]  = d_m1;
+        l_aa.f[1] = a_m1;
+        l_cc.f[1] = c_m1;
+
+        for (int i = 2; i < vec_length<REAL>; i++) {
+          forward_linear_process_line<REAL, shift_c0_on_rank0>(
+              l_a.f[i], a_m1, l_b.f[i], l_c.f[i], c_m1, l_d.f[i], d_m1, b_0, c_0,
+              d_0, sys_size, n + i, rank, nproc);
+          l_d.f[i]  = d_m1;
+          l_aa.f[i] = a_m1;
+          l_cc.f[i] = c_m1;
+        }
       }
 
       store_array_reg(d, &l_d, n, woffset, sys_pads);
@@ -218,38 +221,44 @@ __global__ void trid_linear_forward_pass_aligned(
         load_array_reg(b, &l_b, n, woffset, sys_pads);
         load_array_reg(c, &l_c, n, woffset, sys_pads);
         load_array_reg(d, &l_d, n, woffset, sys_pads);
-#pragma unroll
-        for (int i = 0; i < vec_length<REAL>; i++) {
-          forward_linear_process_line<REAL, shift_c0_on_rank0>(
-              l_a.f[i], a_m1, l_b.f[i], l_c.f[i], c_m1, l_d.f[i], d_m1, b_0,
-              c_0, d_0, sys_size, n + i, rank, nproc);
-          l_d.f[i]  = d_m1;
-          l_aa.f[i] = a_m1;
-          l_cc.f[i] = c_m1;
+
+        if(!padded_sys) {
+          #pragma unroll
+          for (int i = 0; i < vec_length<REAL>; i++) {
+            forward_linear_process_line<REAL, shift_c0_on_rank0>(
+                l_a.f[i], a_m1, l_b.f[i], l_c.f[i], c_m1, l_d.f[i], d_m1, b_0,
+                c_0, d_0, sys_size, n + i, rank, nproc);
+            l_d.f[i]  = d_m1;
+            l_aa.f[i] = a_m1;
+            l_cc.f[i] = c_m1;
+          }
         }
+
         store_array_reg(d, &l_d, n, woffset, sys_pads);
         store_array_reg(cc, &l_cc, n, woffset, sys_pads);
         store_array_reg(aa, &l_aa, n, woffset, sys_pads);
       }
 
-      // Finish off last part that may not fill an entire vector
-      for (int i = n; i < sys_size; i++) {
-        int loc_ind = ind + i;
-        forward_linear_process_line<REAL, shift_c0_on_rank0>(
-            a[loc_ind], a_m1, b[loc_ind], c[loc_ind], c_m1, d[loc_ind], d_m1,
-            b_0, c_0, d_0, sys_size, i, rank, nproc);
-        aa[loc_ind] = a_m1;
-        cc[loc_ind] = c_m1;
-        d[loc_ind]  = d_m1;
+      if(!padded_sys) {
+        // Finish off last part that may not fill an entire vector
+        for (int i = n; i < sys_size; i++) {
+          int loc_ind = ind + i;
+          forward_linear_process_line<REAL, shift_c0_on_rank0>(
+              a[loc_ind], a_m1, b[loc_ind], c[loc_ind], c_m1, d[loc_ind], d_m1,
+              b_0, c_0, d_0, sys_size, i, rank, nproc);
+          aa[loc_ind] = a_m1;
+          cc[loc_ind] = c_m1;
+          d[loc_ind]  = d_m1;
+        }
+        // i = 0
+        if (0 == rank) {
+          aa[ind] = 0;
+        } else {
+          aa[ind] = a[ind] / b_0;
+        }
+        cc[ind] = c_0 / b_0;
+        d[ind]  = d_0 / b_0;
       }
-      // i = 0
-      if (0 == rank) {
-        aa[ind] = 0;
-      } else {
-        aa[ind] = a[ind] / b_0;
-      }
-      cc[ind] = c_0 / b_0;
-      d[ind]  = d_0 / b_0;
     } else if (!padded_sys) {
       trid_linear_forward_single_system<REAL, shift_c0_on_rank0>(
           a, b, c, d, aa, cc, sys_size, ind, rank, nproc);
@@ -302,22 +311,24 @@ __global__ void trid_linear_forward_pass_unaligned(
       REAL b_0 = b[ind];
       REAL c_0 = c[ind];
       REAL d_0 = d[ind];
-      // i = 1 : idx = sys_off +1
-      if (sys_off + 1 < vec_length<REAL>) {
-        forward_linear_process_row1<REAL, shift_c0_on_rank0>(
-            a[ind + 1], a_m1, b[ind + 1], c[ind + 1], c_m1, d[ind + 1], d_m1,
-            b_0, c_0, d_0, sys_size, rank, nproc);
-        aa[ind + 1] = a_m1;
-        cc[ind + 1] = c_m1;
-        d[ind + 1]  = d_m1;
+      if(!padded_sys) {
+        // i = 1 : idx = sys_off +1
+        if (sys_off + 1 < vec_length<REAL>) {
+          forward_linear_process_row1<REAL, shift_c0_on_rank0>(
+              a[ind + 1], a_m1, b[ind + 1], c[ind + 1], c_m1, d[ind + 1], d_m1,
+              b_0, c_0, d_0, sys_size, rank, nproc);
+          aa[ind + 1] = a_m1;
+          cc[ind + 1] = c_m1;
+          d[ind + 1]  = d_m1;
 
-        for (int i = 2; i + sys_off < vec_length<REAL>; i++) {
-          forward_linear_process_line<REAL, shift_c0_on_rank0>(
-              a[ind + i], a_m1, b[ind + i], c[ind + i], c_m1, d[ind + i], d_m1,
-              b_0, c_0, d_0, sys_size, i - sys_off, rank, nproc);
-          d[ind + i]  = d_m1;
-          aa[ind + i] = a_m1;
-          cc[ind + i] = c_m1;
+          for (int i = 2; i + sys_off < vec_length<REAL>; i++) {
+            forward_linear_process_line<REAL, shift_c0_on_rank0>(
+                a[ind + i], a_m1, b[ind + i], c[ind + i], c_m1, d[ind + i], d_m1,
+                b_0, c_0, d_0, sys_size, i - sys_off, rank, nproc);
+            d[ind + i]  = d_m1;
+            aa[ind + i] = a_m1;
+            cc[ind + i] = c_m1;
+          }
         }
       }
 
@@ -328,22 +339,26 @@ __global__ void trid_linear_forward_pass_unaligned(
         load_array_reg_unaligned(b, &l_b, n, tid, sys_pads, sys_size, offset);
         load_array_reg_unaligned(c, &l_c, n, tid, sys_pads, sys_size, offset);
         load_array_reg_unaligned(d, &l_d, n, tid, sys_pads, sys_size, offset);
-#pragma unroll
-        for (int i = 0; i < vec_length<REAL>; i++) {
-          if (i == 0 && n + i - sys_off == 1) {
-            // i = 1 iteration
-            forward_linear_process_row1<REAL, shift_c0_on_rank0>(
-                l_a.f[i], a_m1, l_b.f[i], l_c.f[i], c_m1, l_d.f[i], d_m1, b_0,
-                c_0, d_0, sys_size, rank, nproc);
-          } else {
-            forward_linear_process_line<REAL, shift_c0_on_rank0>(
-                l_a.f[i], a_m1, l_b.f[i], l_c.f[i], c_m1, l_d.f[i], d_m1, b_0,
-                c_0, d_0, sys_size, n + i - sys_off, rank, nproc);
+
+        if(!padded_sys) {
+          #pragma unroll
+          for (int i = 0; i < vec_length<REAL>; i++) {
+            if (i == 0 && n + i - sys_off == 1) {
+              // i = 1 iteration
+              forward_linear_process_row1<REAL, shift_c0_on_rank0>(
+                  l_a.f[i], a_m1, l_b.f[i], l_c.f[i], c_m1, l_d.f[i], d_m1, b_0,
+                  c_0, d_0, sys_size, rank, nproc);
+            } else {
+              forward_linear_process_line<REAL, shift_c0_on_rank0>(
+                  l_a.f[i], a_m1, l_b.f[i], l_c.f[i], c_m1, l_d.f[i], d_m1, b_0,
+                  c_0, d_0, sys_size, n + i - sys_off, rank, nproc);
+            }
+            l_d.f[i]  = d_m1;
+            l_aa.f[i] = a_m1;
+            l_cc.f[i] = c_m1;
           }
-          l_d.f[i]  = d_m1;
-          l_aa.f[i] = a_m1;
-          l_cc.f[i] = c_m1;
         }
+
         store_array_reg_unaligned(d, &l_d, n, tid, sys_pads, sys_size, offset);
         store_array_reg_unaligned(cc, &l_cc, n, tid, sys_pads, sys_size,
                                   offset);
@@ -351,24 +366,26 @@ __global__ void trid_linear_forward_pass_unaligned(
                                   offset);
       }
 
-      // Handle end of unaligned memory
-      for (int i = n; i < sys_size + sys_off; i++) {
-        int loc_ind = ind_floor + i;
-        forward_linear_process_line<REAL, shift_c0_on_rank0>(
-            a[loc_ind], a_m1, b[loc_ind], c[loc_ind], c_m1, d[loc_ind], d_m1,
-            b_0, c_0, d_0, sys_size, i - sys_off, rank, nproc);
-        d[loc_ind]  = d_m1;
-        aa[loc_ind] = a_m1;
-        cc[loc_ind] = c_m1;
+      if(!padded_sys) {
+        // Handle end of unaligned memory
+        for (int i = n; i < sys_size + sys_off; i++) {
+          int loc_ind = ind_floor + i;
+          forward_linear_process_line<REAL, shift_c0_on_rank0>(
+              a[loc_ind], a_m1, b[loc_ind], c[loc_ind], c_m1, d[loc_ind], d_m1,
+              b_0, c_0, d_0, sys_size, i - sys_off, rank, nproc);
+          d[loc_ind]  = d_m1;
+          aa[loc_ind] = a_m1;
+          cc[loc_ind] = c_m1;
+        }
+        // i = 0
+        if (0 == rank) {
+          aa[ind] = 0;
+        } else {
+          aa[ind] = a[ind] / b_0;
+        }
+        cc[ind] = c_0 / b_0;
+        d[ind]  = d_0 / b_0;
       }
-      // i = 0
-      if (0 == rank) {
-        aa[ind] = 0;
-      } else {
-        aa[ind] = a[ind] / b_0;
-      }
-      cc[ind] = c_0 / b_0;
-      d[ind]  = d_0 / b_0;
     } else if (!padded_sys) {
       trid_linear_forward_single_system<REAL, shift_c0_on_rank0>(
           a, b, c, d, aa, cc, sys_size, ind, rank, nproc);
@@ -813,7 +830,7 @@ __global__ void trid_linear_backward_pass_unaligned(
       int ind_floor = ((ind + offset) / align<REAL>)*align<REAL> - offset;
       int sys_off   = ind - ind_floor;
       int end_remainder =
-          sys_size / vec_length<REAL> * vec_length<REAL> - sys_off;
+          ((sys_size - offset) / vec_length<REAL>) * vec_length<REAL> - sys_off;
 
       if (!padded_sys && end_remainder < sys_size) {
         // i = n-1

--- a/scalar/test/cpu_mpi_wrappers.hpp
+++ b/scalar/test/cpu_mpi_wrappers.hpp
@@ -7,32 +7,32 @@
 template <typename Float>
 tridStatus_t tridStridedBatchWrapper(const MpiSolverParams *params,
                                      const Float *a, const Float *b,
-                                     const Float *c, Float *d, Float *u,
-                                     int ndim, int solvedim, const int *dims,
+                                     const Float *c, Float *d, int ndim,
+                                     int solvedim, const int *dims,
                                      const int *pads);
 
 template <>
 tridStatus_t tridStridedBatchWrapper<float>(const MpiSolverParams *params,
                                             const float *a, const float *b,
-                                            const float *c, float *d, float *u,
-                                            int ndim, int solvedim,
-                                            const int *dims, const int *pads) {
+                                            const float *c, float *d, int ndim,
+                                            int solvedim, const int *dims,
+                                            const int *pads) {
   TridParams trid_params;
   trid_params.mpi_params = (void *)params;
-  return tridSmtsvStridedBatch(&trid_params, a, b, c, d, u, ndim, solvedim,
-                               dims, pads);
+  return tridSmtsvStridedBatch(&trid_params, a, b, c, d, ndim, solvedim, dims,
+                               pads);
 }
 
 template <>
 tridStatus_t tridStridedBatchWrapper<double>(const MpiSolverParams *params,
                                              const double *a, const double *b,
                                              const double *c, double *d,
-                                             double *u, int ndim, int solvedim,
+                                             int ndim, int solvedim,
                                              const int *dims, const int *pads) {
   TridParams trid_params;
   trid_params.mpi_params = (void *)params;
-  return tridDmtsvStridedBatch(&trid_params, a, b, c, d, u, ndim, solvedim,
-                               dims, pads);
+  return tridDmtsvStridedBatch(&trid_params, a, b, c, d, ndim, solvedim, dims,
+                               pads);
 }
 
 

--- a/scalar/test/cuda_mpi_wrappers.hpp
+++ b/scalar/test/cuda_mpi_wrappers.hpp
@@ -18,7 +18,7 @@ tridStatus_t tridmtsvStridedBatchMPIWrapper<float>(
     const int *pads) {
   TridParams trid_params;
   trid_params.mpi_params = (void *)params;
-  return tridSmtsvStridedBatch(&trid_params, a, b, c, d, u, ndim, solvedim,
+  return tridSmtsvStridedBatch(&trid_params, a, b, c, d, ndim, solvedim,
                                dims, pads);
 }
 
@@ -29,7 +29,7 @@ tridStatus_t tridmtsvStridedBatchMPIWrapper<double>(
     const int *dims, const int *pads) {
   TridParams trid_params;
   trid_params.mpi_params = (void *)params;
-  return tridDmtsvStridedBatch(&trid_params, a, b, c, d, u, ndim, solvedim,
+  return tridDmtsvStridedBatch(&trid_params, a, b, c, d, ndim, solvedim,
                                dims, pads);
 }
 

--- a/scalar/test/test_cpu.cpp
+++ b/scalar/test/test_cpu.cpp
@@ -10,59 +10,59 @@
 
 template <typename Float>
 tridStatus_t tridStridedBatchWrapper(const Float *a, const Float *b,
-                                     const Float *c, Float *d, Float *u,
-                                     int ndim, int solvedim, const int *dims,
+                                     const Float *c, Float *d, int ndim,
+                                     int solvedim, const int *dims,
                                      const int *pads);
 
 template <>
 tridStatus_t tridStridedBatchWrapper<float>(const float *a, const float *b,
-                                            const float *c, float *d, float *u,
-                                            int ndim, int solvedim,
-                                            const int *dims, const int *pads) {
-  return tridSmtsvStridedBatch(nullptr, a, b, c, d, u, ndim, solvedim, dims, pads);
+                                            const float *c, float *d, int ndim,
+                                            int solvedim, const int *dims,
+                                            const int *pads) {
+  return tridSmtsvStridedBatch(nullptr, a, b, c, d, ndim, solvedim, dims, pads);
 }
 
 template <>
 tridStatus_t tridStridedBatchWrapper<double>(const double *a, const double *b,
                                              const double *c, double *d,
-                                             double *u, int ndim, int solvedim,
+                                             int ndim, int solvedim,
                                              const int *dims, const int *pads) {
-  return tridDmtsvStridedBatch(nullptr, a, b, c, d, u, ndim, solvedim, dims, pads);
+  return tridDmtsvStridedBatch(nullptr, a, b, c, d, ndim, solvedim, dims, pads);
 }
 
 template <typename Float>
 void trid_scalar_wrapper(const Float *a, const Float *b, const Float *c,
-                         Float *d, Float *u, int N, int stride);
+                         Float *d, int N, int stride);
 
 template <>
 void trid_scalar_wrapper<float>(const float *a, const float *b, const float *c,
-                                float *d, float *u, int N, int stride) {
-  trid_scalarS(a, b, c, d, u, N, stride);
+                                float *d, int N, int stride) {
+  trid_scalarS(a, b, c, d, N, stride);
 }
 
 template <>
 void trid_scalar_wrapper<double>(const double *a, const double *b,
-                                 const double *c, double *d, double *u, int N,
+                                 const double *c, double *d, int N,
                                  int stride) {
-  trid_scalarD(a, b, c, d, u, N, stride);
+  trid_scalarD(a, b, c, d, N, stride);
 }
 
 template <typename Float>
 void trid_scalar_vec_wrapper(const Float *a, const Float *b, const Float *c,
-                             Float *d, Float *u, int N, int stride);
+                             Float *d, int N, int stride);
 
 template <>
 void trid_scalar_vec_wrapper<float>(const float *a, const float *b,
-                                    const float *c, float *d, float *u, int N,
+                                    const float *c, float *d, int N,
                                     int stride) {
-  trid_scalar_vecS(a, b, c, d, u, N, stride);
+  trid_scalar_vecS(a, b, c, d, N, stride);
 }
 
 template <>
 void trid_scalar_vec_wrapper<double>(const double *a, const double *b,
-                                     const double *c, double *d, double *u,
-                                     int N, int stride) {
-  trid_scalar_vecD(a, b, c, d, u, N, stride);
+                                     const double *c, double *d, int N,
+                                     int stride) {
+  trid_scalar_vecD(a, b, c, d, N, stride);
 }
 
 template <typename Float> void test_from_file(const std::string &file_name) {
@@ -74,7 +74,6 @@ template <typename Float> void test_from_file(const std::string &file_name) {
                                      mesh.b().data(),     // b
                                      mesh.c().data(),     // c
                                      d.data(),            // d
-                                     nullptr,             // u
                                      mesh.dims().size(),  // ndim
                                      mesh.solve_dim(),    // solvedim
                                      mesh.dims().data(),  // dims
@@ -119,7 +118,6 @@ void test_from_file_padded(const std::string &file_name) {
                                      b_p.data() + offset_to_first_element, // b
                                      c_p.data() + offset_to_first_element, // c
                                      d_p.data() + offset_to_first_element, // d
-                                     nullptr,                              // u
                                      mesh.dims().size(),  // ndim
                                      mesh.solve_dim(),    // solvedim
                                      mesh.dims().data(),  // dims
@@ -144,7 +142,6 @@ void test_from_file_scalar(const std::string &file_name) {
                              mesh.b().data(), // b
                              mesh.c().data(), // c
                              d.data(),        // d
-                             nullptr,         // u
                              N,               // N
                              stride);         // stride
 
@@ -169,7 +166,6 @@ void test_from_file_scalar_vec(const std::string &file_name) {
                                  b.data(), // b
                                  c.data(), // c
                                  d.data(), // d
-                                 nullptr,  // u
                                  N,        // N
                                  stride);  // stride
 

--- a/scalar/test/test_cpu_mpi.cpp
+++ b/scalar/test/test_cpu_mpi.cpp
@@ -77,7 +77,7 @@ void test_solver_from_file(const std::string &file_name) {
                local_sizes.size() - 1);
   // Solve the equations
   tridStridedBatchWrapper<Float>(&params, a.data(), b.data(), c.data(), d.data(),
-                                 nullptr, mesh.dims().size(), mesh.solve_dim(),
+                                 mesh.dims().size(), mesh.solve_dim(),
                                  local_sizes.data(), local_sizes.data());
 
   // Check result
@@ -174,7 +174,7 @@ void test_solver_from_file_padded(const std::string &file_name) {
   tridStridedBatchWrapper<Float>(&params, a_p.data() + offset_to_first_element,
                                  b_p.data() + offset_to_first_element,
                                  c_p.data() + offset_to_first_element,
-                                 d_p.data() + offset_to_first_element, nullptr,
+                                 d_p.data() + offset_to_first_element,
                                  mesh.dims().size(), mesh.solve_dim(),
                                  local_sizes.data(), padded_dims.data());
 

--- a/scalar/test/test_cuda.cu
+++ b/scalar/test/test_cuda.cu
@@ -6,34 +6,33 @@
 
 template <typename Float>
 tridStatus_t tridStridedBatchWrapper(const Float *a, const Float *b,
-                                     const Float *c, Float *d, Float *u,
-                                     int ndim, int solvedim, int *dims,
-                                     int *pads);
+                                     const Float *c, Float *d, int ndim,
+                                     int solvedim, int *dims, int *pads);
 
 template <>
 tridStatus_t tridStridedBatchWrapper<float>(const float *a, const float *b,
-                                            const float *c, float *d, float *u,
-                                            int ndim, int solvedim, int *dims,
+                                            const float *c, float *d, int ndim,
+                                            int solvedim, int *dims,
                                             int *pads) {
   TridParams trid_params;
   trid_params.opts[0] = ndim == 1 ? 1 : 0;
   trid_params.opts[1] = 0;
   trid_params.opts[2] = 0;
-  return tridSmtsvStridedBatch(&trid_params, a, b, c, d, u, ndim, solvedim,
-                               dims, pads);
+  return tridSmtsvStridedBatch(&trid_params, a, b, c, d, ndim, solvedim, dims,
+                               pads);
 }
 
 template <>
 tridStatus_t tridStridedBatchWrapper<double>(const double *a, const double *b,
                                              const double *c, double *d,
-                                             double *u, int ndim, int solvedim,
-                                             int *dims, int *pads) {
+                                             int ndim, int solvedim, int *dims,
+                                             int *pads) {
   TridParams trid_params;
   trid_params.opts[0] = ndim == 1 ? 1 : 0;
   trid_params.opts[1] = 0;
   trid_params.opts[2] = 0;
-  return tridDmtsvStridedBatch(&trid_params, a, b, c, d, u, ndim, solvedim,
-                               dims, pads);
+  return tridDmtsvStridedBatch(&trid_params, a, b, c, d, ndim, solvedim, dims,
+                               pads);
 }
 
 template <typename Float> void test_from_file(const std::string &file_name) {
@@ -49,7 +48,6 @@ template <typename Float> void test_from_file(const std::string &file_name) {
                                      device_mesh.b().data(), // b
                                      device_mesh.c().data(), // c
                                      device_mesh.d().data(), // d
-                                     nullptr,                // u
                                      mesh.dims().size(),     // ndim
                                      mesh.solve_dim(),       // solvedim
                                      dims.data(),            // dims
@@ -109,7 +107,6 @@ void test_from_file_padded(const std::string &file_name) {
                                      b_d + offset_to_first_element, // b
                                      c_d + offset_to_first_element, // c
                                      d_d + offset_to_first_element, // d
-                                     nullptr,                       // u
                                      mesh.dims().size(),            // ndim
                                      mesh.solve_dim(),              // solvedim
                                      dims.data(),                   // dims


### PR DESCRIPTION
This pull request is for some fixes to do with padding that I came across while testing the OPS integration. The fixes were:
- For single node CPU x transpose pass, correcting a round down
- For MPI+CUDA the x dim forward pass, it was writing to padding (left over from when we changed from using a dd array to now writing straight to the d array). It's now no longer writing to padding.
- For MPI+CUDA the iterative x dim forward pass, it was doing the same thing with writing to padding, fixed in the same way. 
- For MPI+CUDA the iterative x dim unaligned backwards pass, corrected an offset calculation.

This now passes all the additional tests I have for the OPS integration that deal with different padding situations (as well as the existing Tridsolver tests). Let me know if there are any issues with this that I have missed.